### PR TITLE
points_generate2

### DIFF
--- a/nn/nn.h
+++ b/nn/nn.h
@@ -108,7 +108,7 @@ void points_getrange(int n, point points[], double zoom, double* xmin, double* x
  * @param nout Pointer to number of output points
  * @param pout Pointer to array of output points [*nout]
  */
-void points_generate(double xmin, double xmax, double ymin, double ymax, int nx, int ny, int* nout, point** pout);
+void points_generate2(double xmin, double xmax, double ymin, double ymax, int nx, int ny, int* nout, point** pout);
 
 /** Reads array of points from a columnar file.
  *

--- a/nn/nnbathy.c
+++ b/nn/nnbathy.c
@@ -504,7 +504,7 @@ int main(int argc, char* argv[])
          * which do not point to NaNs 
          */
         points_getrange(nin, pin, s->zoom, &s->xmin, &s->xmax, &s->ymin, &s->ymax);
-        points_generate(s->xmin, s->xmax, s->ymin, s->ymax, s->nx, s->ny, &nout, &pout);
+        points_generate2(s->xmin, s->xmax, s->ymin, s->ymax, s->nx, s->ny, &nout, &pout);
     } else
         points_read(s->fout, 2, &nout, &pout);
 

--- a/nn/nncommon.c
+++ b/nn/nncommon.c
@@ -379,7 +379,7 @@ void points_getrange(int n, point points[], double zoom, double* xmin, double* x
  * @param nout Pointer to number of output points
  * @param pout Pointer to array of output points [*nout]
  */
-void points_generate(double xmin, double xmax, double ymin, double ymax, int nx, int ny, int* nout, point** pout)
+void points_generate2(double xmin, double xmax, double ymin, double ymax, int nx, int ny, int* nout, point** pout)
 {
     double stepx, stepy;
     double x0, xx, yy;


### PR DESCRIPTION
This PR fixes the error below when running `make tests`:

```
+ make tests
gcc -o nnai_test nnai.c -DNNAI_TEST -g -O2 -Wall -pedantic -I. -lm libnn.a
nnai.c: In function ‘main’:
nnai.c:285:5: warning: implicit declaration of function ‘points_generate2’ [-Wimplicit-function-declaration]
     points_generate2(-0.1, 1.1, -0.1, 1.1, nx, nx, &nout, &pout);
     ^
/tmp/ccQkkMK7.o: In function `main':
/home/filipe/miniconda/conda-bld/work/nn/nnai.c:285: undefined reference to `points_generate2'
collect2: error: ld returned 1 exit status
makefile:91: recipe for target 'nnai_test' failed
make: *** [nnai_test] Error 1
```

Note that I am not sure if the actual name for this function should be `points_generate2` or `points_generate`.